### PR TITLE
pass .only() or .exclude() fields to BaseDocument subclasses

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -86,6 +86,22 @@ class BaseDocument(object):
 
         _created = values.pop("_created", True)
 
+
+        # will raise exception if we try to retrieve fields not in .only() and in .exclude() 
+        _requested_fields = values.pop('_requested_fields', None)
+        _requested_fields_value = values.pop('_requested_fields_value', None)
+
+        if _requested_fields is not None:
+            all_dbfields = set(self._reverse_db_field_map)
+            _requested_fields = _requested_fields or []
+            if _requested_fields_value is None or _requested_fields_value == 1:
+                if _requested_fields:
+                    self._requested_fields = set(_requested_fields)
+                else:
+                    self._requested_fields = set(all_dbfields)
+            else:
+                self._requested_fields = set(all_dbfields) - set(_requested_fields)
+        
         signals.pre_init.send(self.__class__, document=self, values=values)
 
         # Check if there are undefined fields supplied to the constructor,
@@ -726,8 +742,11 @@ class BaseDocument(object):
         return cls._meta.get("collection", None)
 
     @classmethod
-    def _from_son(cls, son, _auto_dereference=True, only_fields=None, created=False):
+    def _from_son(cls, son, _auto_dereference=True, only_fields=None, created=False, _requested_fields=None, _requested_fields_value=None):
         """Create an instance of a Document (subclass) from a PyMongo SON."""
+        EmbeddedDocumentField = _import_class("EmbeddedDocumentField")
+        ComplexBaseField = _import_class("ComplexBaseField")
+
         if not only_fields:
             only_fields = []
 
@@ -756,19 +775,35 @@ class BaseDocument(object):
         if not _auto_dereference:
             fields = copy.deepcopy(fields)
 
+        _requested_fields_dict = {}
+        if _requested_fields is not None:
+            for field_ in _requested_fields:
+                base, _, rest = field_.partition('.')
+                _requested_fields_dict[base] = _requested_fields_dict.get(base, [])
+                if rest:
+                    _requested_fields_dict[base].append(rest)
+
         for field_name, field in iteritems(fields):
             field._auto_dereference = _auto_dereference
+            embedded_kwargs = {}
+            if isinstance(field, (EmbeddedDocumentField, ComplexBaseField)):
+                embedded_kwargs = {
+                    '_requested_fields': _requested_fields_dict.get(field.db_field), 
+                    '_requested_fields_value': _requested_fields_value
+                }
+                if _requested_fields_value == 0 and _requested_fields_dict.get(field.db_field, None):
+                    _requested_fields_dict.pop(field.db_field, None)
+
             if field.db_field in data:
                 value = data[field.db_field]
                 try:
                     data[field_name] = (
-                        value if value is None else field.to_python(value)
+                        value if value is None else field.to_python(value, **embedded_kwargs)
                     )
                     if field_name != field.db_field:
                         del data[field.db_field]
                 except (AttributeError, ValueError) as e:
                     errors_dict[field_name] = e
-
         if errors_dict:
             errors = "\n".join(["%s - %s" % (k, v) for k, v in errors_dict.items()])
             msg = "Invalid data to create a `%s` instance.\n%s" % (
@@ -780,9 +815,10 @@ class BaseDocument(object):
         # In STRICT documents, remove any keys that aren't in cls._fields
         if cls.STRICT:
             data = {k: v for k, v in iteritems(data) if k in cls._fields}
-
+        
         obj = cls(
-            __auto_convert=False, _created=created, __only_fields=only_fields, **data
+            __auto_convert=False, _created=created, __only_fields=only_fields, 
+            _requested_fields=_requested_fields_dict.keys(), _requested_fields_value=_requested_fields_value, **data
         )
         obj._changed_fields = []
         if not _auto_dereference:

--- a/mongoengine/errors.py
+++ b/mongoengine/errors.py
@@ -16,6 +16,7 @@ __all__ = (
     "ValidationError",
     "SaveConditionError",
     "DeprecatedError",
+    "FieldIsNotRetrieved"
 )
 
 
@@ -64,6 +65,12 @@ class FieldDoesNotExist(Exception):
     you should set the :attr:`strict` to ``False``
     in the :attr:`meta` dictionary.
     """
+
+class FieldIsNotRetrieved(Exception):
+    """Raised when try to get field not in .only() or in .exclude()
+    Works only if 'check_fields_retrieved' is True in meta
+    """
+    pass
 
 
 class ValidationError(AssertionError):

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -745,10 +745,11 @@ class EmbeddedDocumentField(BaseField):
 
         return self.document_type_obj
 
-    def to_python(self, value):
+    def to_python(self, value, _requested_fields=None, _requested_fields_value=None):
         if not isinstance(value, self.document_type):
             return self.document_type._from_son(
-                value, _auto_dereference=self._auto_dereference
+                value, _auto_dereference=self._auto_dereference,
+                _requested_fields=_requested_fields, _requested_fields_value=_requested_fields_value
             )
         return value
 

--- a/tests/check_fields_retrieved/field_list.py
+++ b/tests/check_fields_retrieved/field_list.py
@@ -1,0 +1,433 @@
+import sys
+sys.path[0:0] = [""]
+
+import unittest
+
+from mongoengine import *
+from mongoengine.queryset import QueryFieldList
+
+__all__ = ("QueryFieldListTest", "OnlyExcludeAllTest")
+
+
+class QueryFieldListTest(unittest.TestCase):
+
+    def test_empty(self):
+        q = QueryFieldList()
+        self.assertFalse(q)
+
+        q = QueryFieldList(always_include=['_cls'])
+        self.assertFalse(q)
+
+    def test_include_include(self):
+        q = QueryFieldList()
+        q += QueryFieldList(fields=['a', 'b'], value=QueryFieldList.ONLY, _only_called=True)
+        self.assertEqual(q.as_dict(), {'a': 1, 'b': 1})
+        q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.ONLY)
+        self.assertEqual(q.as_dict(), {'a': 1, 'b': 1, 'c': 1})
+
+    def test_include_exclude(self):
+        q = QueryFieldList()
+        q += QueryFieldList(fields=['a', 'b'], value=QueryFieldList.ONLY)
+        self.assertEqual(q.as_dict(), {'a': 1, 'b': 1})
+        q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.EXCLUDE)
+        self.assertEqual(q.as_dict(), {'a': 1})
+
+    def test_exclude_exclude(self):
+        q = QueryFieldList()
+        q += QueryFieldList(fields=['a', 'b'], value=QueryFieldList.EXCLUDE)
+        self.assertEqual(q.as_dict(), {'a': 0, 'b': 0})
+        q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.EXCLUDE)
+        self.assertEqual(q.as_dict(), {'a': 0, 'b': 0, 'c': 0})
+
+    def test_exclude_include(self):
+        q = QueryFieldList()
+        q += QueryFieldList(fields=['a', 'b'], value=QueryFieldList.EXCLUDE)
+        self.assertEqual(q.as_dict(), {'a': 0, 'b': 0})
+        q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.ONLY)
+        self.assertEqual(q.as_dict(), {'c': 1})
+
+    def test_always_include(self):
+        q = QueryFieldList(always_include=['x', 'y'])
+        q += QueryFieldList(fields=['a', 'b', 'x'], value=QueryFieldList.EXCLUDE)
+        q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.ONLY)
+        self.assertEqual(q.as_dict(), {'x': 1, 'y': 1, 'c': 1})
+
+    def test_reset(self):
+        q = QueryFieldList(always_include=['x', 'y'])
+        q += QueryFieldList(fields=['a', 'b', 'x'], value=QueryFieldList.EXCLUDE)
+        q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.ONLY)
+        self.assertEqual(q.as_dict(), {'x': 1, 'y': 1, 'c': 1})
+        q.reset()
+        self.assertFalse(q)
+        q += QueryFieldList(fields=['b', 'c'], value=QueryFieldList.ONLY)
+        self.assertEqual(q.as_dict(), {'x': 1, 'y': 1, 'b': 1, 'c': 1})
+
+    def test_using_a_slice(self):
+        q = QueryFieldList()
+        q += QueryFieldList(fields=['a'], value={"$slice": 5})
+        self.assertEqual(q.as_dict(), {'a': {"$slice": 5}})
+
+
+class OnlyExcludeAllTest(unittest.TestCase):
+
+    def setUp(self):
+        connect(db='mongoenginetest')
+
+        class Person(Document):
+            name = StringField()
+            age = IntField()
+            meta = {'allow_inheritance': True}
+
+        Person.drop_collection()
+        self.Person = Person
+
+    def test_mixing_only_exclude(self):
+
+        class MyDoc(Document):
+            a = StringField()
+            b = StringField()
+            c = StringField()
+            d = StringField()
+            e = StringField()
+            f = StringField()
+
+        include = ['a', 'b', 'c', 'd', 'e']
+        exclude = ['d', 'e']
+        only = ['b', 'c']
+
+        qs = MyDoc.objects.fields(**dict(((i, 1) for i in include)))
+        self.assertEqual(qs._loaded_fields.as_dict(),
+                         {'a': 1, 'b': 1, 'c': 1, 'd': 1, 'e': 1})
+        qs = qs.only(*only)
+        self.assertEqual(qs._loaded_fields.as_dict(), {'b': 1, 'c': 1})
+        qs = qs.exclude(*exclude)
+        self.assertEqual(qs._loaded_fields.as_dict(), {'b': 1, 'c': 1})
+
+        qs = MyDoc.objects.fields(**dict(((i, 1) for i in include)))
+        qs = qs.exclude(*exclude)
+        self.assertEqual(qs._loaded_fields.as_dict(), {'a': 1, 'b': 1, 'c': 1})
+        qs = qs.only(*only)
+        self.assertEqual(qs._loaded_fields.as_dict(), {'b': 1, 'c': 1})
+
+        qs = MyDoc.objects.exclude(*exclude)
+        qs = qs.fields(**dict(((i, 1) for i in include)))
+        self.assertEqual(qs._loaded_fields.as_dict(), {'a': 1, 'b': 1, 'c': 1})
+        qs = qs.only(*only)
+        self.assertEqual(qs._loaded_fields.as_dict(), {'b': 1, 'c': 1})
+
+    def test_slicing(self):
+
+        class MyDoc(Document):
+            a = ListField()
+            b = ListField()
+            c = ListField()
+            d = ListField()
+            e = ListField()
+            f = ListField()
+
+        include = ['a', 'b', 'c', 'd', 'e']
+        exclude = ['d', 'e']
+        only = ['b', 'c']
+
+        qs = MyDoc.objects.fields(**dict(((i, 1) for i in include)))
+        qs = qs.exclude(*exclude)
+        qs = qs.only(*only)
+        qs = qs.fields(slice__b=5)
+        self.assertEqual(qs._loaded_fields.as_dict(),
+                         {'b': {'$slice': 5}, 'c': 1})
+
+        qs = qs.fields(slice__c=[5, 1])
+        self.assertEqual(qs._loaded_fields.as_dict(),
+                         {'b': {'$slice': 5}, 'c': {'$slice': [5, 1]}})
+
+        qs = qs.exclude('c')
+        self.assertEqual(qs._loaded_fields.as_dict(),
+                         {'b': {'$slice': 5}})
+
+    def test_only(self):
+        """WILL FAIL. Ensure that QuerySet.only only returns the requested fields.
+        """
+        person = self.Person(name='test', age=25)
+        person.save()
+
+        obj = self.Person.objects.only('name').get()
+        self.assertEqual(obj.name, person.name)
+        self.assertEqual(obj.age, None)
+
+        obj = self.Person.objects.only('age').get()
+        self.assertEqual(obj.name, None)
+        self.assertEqual(obj.age, person.age)
+
+        obj = self.Person.objects.only('name', 'age').get()
+        self.assertEqual(obj.name, person.name)
+        self.assertEqual(obj.age, person.age)
+
+        obj = self.Person.objects.only(*('id', 'name',)).get()
+        self.assertEqual(obj.name, person.name)
+        self.assertEqual(obj.age, None)
+
+        # Check polymorphism still works
+        class Employee(self.Person):
+            salary = IntField(db_field='wage')
+
+        employee = Employee(name='test employee', age=40, salary=30000)
+        employee.save()
+
+        obj = self.Person.objects(id=employee.id).only('age').get()
+        self.assertTrue(isinstance(obj, Employee))
+
+        # Check field names are looked up properly
+        obj = Employee.objects(id=employee.id).only('salary').get()
+        self.assertEqual(obj.salary, employee.salary)
+        self.assertEqual(obj.name, None)
+
+    def test_only_with_subfields(self):
+        """WILLFAIL"""
+        class User(EmbeddedDocument):
+            name = StringField()
+            email = StringField()
+
+        class Comment(EmbeddedDocument):
+            title = StringField()
+            text = StringField()
+
+        class BlogPost(Document):
+            content = StringField()
+            author = EmbeddedDocumentField(User)
+            comments = ListField(EmbeddedDocumentField(Comment))
+
+        BlogPost.drop_collection()
+
+        post = BlogPost(content='Had a good coffee today...')
+        post.author = User(name='Test User')
+        post.comments = [Comment(title='I aggree', text='Great post!'), Comment(title='Coffee', text='I hate coffee')]
+        post.save()
+
+        obj = BlogPost.objects.only('author.name', ).get()
+
+        self.assertEqual(obj.content, None)
+        self.assertEqual(obj.author.email, None)
+        self.assertEqual(obj.author.name, 'Test User')
+        self.assertEqual(obj.comments, [])
+
+        obj = BlogPost.objects.only('content', 'comments.title',).get()
+        self.assertEqual(obj.content, 'Had a good coffee today...')
+        self.assertEqual(obj.author, None)
+        self.assertEqual(obj.comments[0].title, 'I aggree')
+        self.assertEqual(obj.comments[1].title, 'Coffee')
+        self.assertEqual(obj.comments[0].text, None)
+        self.assertEqual(obj.comments[1].text, None)
+
+        obj = BlogPost.objects.only('comments',).get()
+        self.assertEqual(obj.content, None)
+        self.assertEqual(obj.author, None)
+        self.assertEqual(obj.comments[0].title, 'I aggree')
+        self.assertEqual(obj.comments[1].title, 'Coffee')
+        self.assertEqual(obj.comments[0].text, 'Great post!')
+        self.assertEqual(obj.comments[1].text, 'I hate coffee')
+
+        BlogPost.drop_collection()
+
+    def test_exclude(self):
+        """WILL FAIL"""
+        class User(EmbeddedDocument):
+            name = StringField()
+            email = StringField()
+
+        class Comment(EmbeddedDocument):
+            title = StringField()
+            text = StringField()
+
+        class BlogPost(Document):
+            content = StringField()
+            author = EmbeddedDocumentField(User)
+            comments = ListField(EmbeddedDocumentField(Comment))
+
+        BlogPost.drop_collection()
+
+        post = BlogPost(content='Had a good coffee today...')
+        post.author = User(name='Test User')
+        post.comments = [Comment(title='I aggree', text='Great post!'), Comment(title='Coffee', text='I hate coffee')]
+        post.save()
+
+        obj = BlogPost.objects.exclude('author', 'comments.text').get()
+        self.assertEqual(obj.author, None)
+        self.assertEqual(obj.content, 'Had a good coffee today...')
+        self.assertEqual(obj.comments[0].title, 'I aggree')
+        self.assertEqual(obj.comments[0].text, None)
+
+        BlogPost.drop_collection()
+
+    def test_exclude_only_combining(self):
+        """WILL FAIL"""
+
+        class Attachment(EmbeddedDocument):
+            name = StringField()
+            content = StringField()
+
+        class Email(Document):
+            sender = StringField()
+            to = StringField()
+            subject = StringField()
+            body = StringField()
+            content_type = StringField()
+            attachments = ListField(EmbeddedDocumentField(Attachment))
+
+        Email.drop_collection()
+        email = Email(sender='me', to='you', subject='From Russia with Love', body='Hello!', content_type='text/plain')
+        email.attachments = [
+            Attachment(name='file1.doc', content='ABC'),
+            Attachment(name='file2.doc', content='XYZ'),
+        ]
+        email.save()
+
+        obj = Email.objects.exclude('content_type').exclude('body').get()
+        self.assertEqual(obj.sender, 'me')
+        self.assertEqual(obj.to, 'you')
+        self.assertEqual(obj.subject, 'From Russia with Love')
+        self.assertEqual(obj.body, None)
+        self.assertEqual(obj.content_type, None)
+
+        obj = Email.objects.only('sender', 'to').exclude('body', 'sender').get()
+        self.assertEqual(obj.sender, None)
+        self.assertEqual(obj.to, 'you')
+        # WILL_FAIL
+        self.assertEqual(obj.subject, None)
+        self.assertEqual(obj.body, None)
+        self.assertEqual(obj.content_type, None)
+
+        obj = Email.objects.exclude('attachments.content').exclude('body').only('to', 'attachments.name').get()
+        self.assertEqual(obj.attachments[0].name, 'file1.doc')
+        self.assertEqual(obj.attachments[0].content, None)
+        self.assertEqual(obj.sender, None)
+        self.assertEqual(obj.to, 'you')
+        self.assertEqual(obj.subject, None)
+        self.assertEqual(obj.body, None)
+        self.assertEqual(obj.content_type, None)
+
+        Email.drop_collection()
+
+    def test_all_fields(self):
+
+        class Email(Document):
+            sender = StringField()
+            to = StringField()
+            subject = StringField()
+            body = StringField()
+            content_type = StringField()
+
+        Email.drop_collection()
+
+        email = Email(sender='me', to='you', subject='From Russia with Love', body='Hello!', content_type='text/plain')
+        email.save()
+
+        obj = Email.objects.exclude('content_type', 'body').only('to', 'body').all_fields().get()
+        # WILL_FAIL
+        self.assertEqual(obj.sender, 'me')
+        self.assertEqual(obj.to, 'you')
+        self.assertEqual(obj.subject, 'From Russia with Love')
+        self.assertEqual(obj.body, 'Hello!')
+        self.assertEqual(obj.content_type, 'text/plain')
+
+        Email.drop_collection()
+
+    def test_slicing_fields(self):
+        """Ensure that query slicing an array works.
+        """
+        class Numbers(Document):
+            n = ListField(IntField())
+
+        Numbers.drop_collection()
+
+        numbers = Numbers(n=[0, 1, 2, 3, 4, 5, -5, -4, -3, -2, -1])
+        numbers.save()
+
+        # first three
+        numbers = Numbers.objects.fields(slice__n=3).get()
+        self.assertEqual(numbers.n, [0, 1, 2])
+
+        # last three
+        numbers = Numbers.objects.fields(slice__n=-3).get()
+        self.assertEqual(numbers.n, [-3, -2, -1])
+
+        # skip 2, limit 3
+        numbers = Numbers.objects.fields(slice__n=[2, 3]).get()
+        self.assertEqual(numbers.n, [2, 3, 4])
+
+        # skip to fifth from last, limit 4
+        numbers = Numbers.objects.fields(slice__n=[-5, 4]).get()
+        self.assertEqual(numbers.n, [-5, -4, -3, -2])
+
+        # skip to fifth from last, limit 10
+        numbers = Numbers.objects.fields(slice__n=[-5, 10]).get()
+        self.assertEqual(numbers.n, [-5, -4, -3, -2, -1])
+
+        # skip to fifth from last, limit 10 dict method
+        numbers = Numbers.objects.fields(n={"$slice": [-5, 10]}).get()
+        self.assertEqual(numbers.n, [-5, -4, -3, -2, -1])
+
+    def test_slicing_nested_fields(self):
+        """Ensure that query slicing an embedded array works. WILL FAIL
+        """
+
+        class EmbeddedNumber(EmbeddedDocument):
+            n = ListField(IntField())
+
+        class Numbers(Document):
+            embedded = EmbeddedDocumentField(EmbeddedNumber)
+
+        Numbers.drop_collection()
+
+        numbers = Numbers()
+        numbers.embedded = EmbeddedNumber(n=[0, 1, 2, 3, 4, 5, -5, -4, -3, -2, -1])
+        numbers.save()
+
+        # first three
+        numbers = Numbers.objects.fields(slice__embedded__n=3).get()
+        self.assertEqual(numbers.embedded.n, [0, 1, 2])
+
+        # last three
+        numbers = Numbers.objects.fields(slice__embedded__n=-3).get()
+        self.assertEqual(numbers.embedded.n, [-3, -2, -1])
+
+        # skip 2, limit 3
+        numbers = Numbers.objects.fields(slice__embedded__n=[2, 3]).get()
+        self.assertEqual(numbers.embedded.n, [2, 3, 4])
+
+        # skip to fifth from last, limit 4
+        numbers = Numbers.objects.fields(slice__embedded__n=[-5, 4]).get()
+        self.assertEqual(numbers.embedded.n, [-5, -4, -3, -2])
+
+        # skip to fifth from last, limit 10
+        numbers = Numbers.objects.fields(slice__embedded__n=[-5, 10]).get()
+        self.assertEqual(numbers.embedded.n, [-5, -4, -3, -2, -1])
+
+        # skip to fifth from last, limit 10 dict method
+        numbers = Numbers.objects.fields(embedded__n={"$slice": [-5, 10]}).get()
+        self.assertEqual(numbers.embedded.n, [-5, -4, -3, -2, -1])
+
+
+    def test_exclude_from_subclasses_docs(self):
+        """WILL FAIL"""
+        class Base(Document):
+            username = StringField()
+
+            meta = {'allow_inheritance': True}
+
+        class Anon(Base):
+            anon = BooleanField()
+
+        class User(Base):
+            password = StringField()
+            wibble = StringField()
+
+        Base.drop_collection()
+        User(username="mongodb", password="secret").save()
+
+        user = Base.objects().exclude("password", "wibble").first()
+        self.assertEqual(user.password, None)
+
+        self.assertRaises(LookUpError, Base.objects.exclude, "made_up")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/check_fields_retrieved/queryset.py
+++ b/tests/check_fields_retrieved/queryset.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+
+import datetime
+import unittest
+import uuid
+from decimal import Decimal
+
+from bson import DBRef, ObjectId
+import pymongo
+from pymongo.read_preferences import ReadPreference
+from pymongo.results import UpdateResult
+import six
+from six import iteritems
+
+from mongoengine import *
+from mongoengine.connection import get_connection, get_db
+from mongoengine.context_managers import query_counter, switch_db
+from mongoengine.errors import InvalidQueryError
+from mongoengine.mongodb_support import MONGODB_36, get_mongodb_version
+from mongoengine.queryset import (
+    DoesNotExist,
+    MultipleObjectsReturned,
+    QuerySet,
+    QuerySetManager,
+    queryset_manager,
+)
+
+Document._meta['check_fields_retrieved'] = True
+
+class db_ops_tracker(query_counter):
+    def get_ops(self):
+        ignore_query = dict(self._ignored_query)
+        ignore_query["command.count"] = {
+            "$ne": "system.profile"
+        }  # Ignore the query issued by query_counter
+        return list(self.db.system.profile.find(ignore_query))
+
+
+def get_key_compat(mongo_ver):
+    ORDER_BY_KEY = "sort"
+    CMD_QUERY_KEY = "command" if mongo_ver >= MONGODB_36 else "query"
+    return ORDER_BY_KEY, CMD_QUERY_KEY
+
+
+class QuerySetTest(unittest.TestCase):
+    def setUp(self):
+        connect(db="mongoenginetest")
+        connect(db="mongoenginetest2", alias="test2")
+
+        class PersonMeta(EmbeddedDocument):
+            weight = IntField()
+
+        class Person(Document):
+            name = StringField()
+            age = IntField()
+            person_meta = EmbeddedDocumentField(PersonMeta)
+            meta = {"allow_inheritance": True}
+
+        Person.drop_collection()
+        self.PersonMeta = PersonMeta
+        self.Person = Person
+
+        self.mongodb_version = get_mongodb_version()
+
+    def test_limit(self):
+        """WILL FAIL. Ensure that QuerySet.limit works as expected."""
+        user_a = self.Person.objects.create(name="User A", age=20)
+        user_b = self.Person.objects.create(name="User B", age=30)
+
+        # Test limit on a new queryset
+        people = list(self.Person.objects.limit(1))
+        self.assertEqual(len(people), 1)
+        self.assertEqual(people[0], user_a)
+
+        # Test limit on an existing queryset
+        people = self.Person.objects
+        self.assertEqual(len(people), 2)
+        people2 = people.limit(1)
+        self.assertEqual(len(people), 2)
+        self.assertEqual(len(people2), 1)
+        self.assertEqual(people2[0], user_a)
+
+        # Test limit with 0 as parameter
+        people = self.Person.objects.limit(0)
+        self.assertEqual(people.count(with_limit_and_skip=True), 2)
+        self.assertEqual(len(people), 2)
+
+        # Test chaining of only after limit
+        person = self.Person.objects().limit(1).only("name").first()
+        self.assertEqual(person, user_a)
+        self.assertEqual(person.name, "User A")
+        self.assertEqual(person.age, None)
+
+    def test_skip(self):
+        """WILL FAIL. Ensure that QuerySet.skip works as expected."""
+        user_a = self.Person.objects.create(name="User A", age=20)
+        user_b = self.Person.objects.create(name="User B", age=30)
+
+        # Test skip on a new queryset
+        people = list(self.Person.objects.skip(1))
+        self.assertEqual(len(people), 1)
+        self.assertEqual(people[0], user_b)
+
+        # Test skip on an existing queryset
+        people = self.Person.objects
+        self.assertEqual(len(people), 2)
+        people2 = people.skip(1)
+        self.assertEqual(len(people), 2)
+        self.assertEqual(len(people2), 1)
+        self.assertEqual(people2[0], user_b)
+
+        # Test chaining of only after skip
+        person = self.Person.objects().skip(1).only("name").first()
+        self.assertEqual(person, user_b)
+        self.assertEqual(person.name, "User B")
+        self.assertEqual(person.age, None)
+
+        self.assertEqual(result, 1)
+        result = self.Person.objects.update_one(
+            set__name="Test User", write_concern={"w": 0}
+        )
+        self.assertEqual(result, None)
+    
+    def test_read_preference(self):
+        """WILL FAIL"""
+        class Bar(Document):
+            txt = StringField()
+
+            meta = {"indexes": ["txt"]}
+
+        Bar.drop_collection()
+        bar = Bar.objects.create(txt="xyz")
+
+        bars = list(Bar.objects.read_preference(ReadPreference.PRIMARY))
+        self.assertEqual(bars, [bar])
+
+        bars = Bar.objects.read_preference(ReadPreference.SECONDARY_PREFERRED)
+        self.assertEqual(bars._read_preference, ReadPreference.SECONDARY_PREFERRED)
+        self.assertEqual(
+            bars._cursor._Cursor__read_preference, ReadPreference.SECONDARY_PREFERRED
+        )
+
+        # Make sure that `.read_preference(...)` does accept string values.
+        self.assertRaises(TypeError, Bar.objects.read_preference, "Primary")
+
+        # Make sure read preference is respected after a `.skip(...)`.
+        bars = Bar.objects.skip(1).read_preference(ReadPreference.SECONDARY_PREFERRED)
+        self.assertEqual(bars._read_preference, ReadPreference.SECONDARY_PREFERRED)
+        self.assertEqual(
+            bars._cursor._Cursor__read_preference, ReadPreference.SECONDARY_PREFERRED
+        )
+
+        # Make sure read preference is respected after a `.limit(...)`.
+        bars = Bar.objects.limit(1).read_preference(ReadPreference.SECONDARY_PREFERRED)
+        self.assertEqual(bars._read_preference, ReadPreference.SECONDARY_PREFERRED)
+        self.assertEqual(
+            bars._cursor._Cursor__read_preference, ReadPreference.SECONDARY_PREFERRED
+        )
+
+        # Make sure read preference is respected after an `.order_by(...)`.
+        bars = Bar.objects.order_by("txt").read_preference(
+            ReadPreference.SECONDARY_PREFERRED
+        )
+        self.assertEqual(bars._read_preference, ReadPreference.SECONDARY_PREFERRED)
+        self.assertEqual(
+            bars._cursor._Cursor__read_preference, ReadPreference.SECONDARY_PREFERRED
+        )
+
+        # Make sure read preference is respected after a `.hint(...)`.
+        bars = Bar.objects.hint([("txt", 1)]).read_preference(
+            ReadPreference.SECONDARY_PREFERRED
+        )
+        self.assertEqual(bars._read_preference, ReadPreference.SECONDARY_PREFERRED)
+        self.assertEqual(
+            bars._cursor._Cursor__read_preference, ReadPreference.SECONDARY_PREFERRED
+        )
+
+    def test_order_by_chaining(self):
+        """WILL FAIL. Ensure that an order_by query chains properly and allows .only()
+        """
+        self.Person(name="User B", age=40).save()
+        self.Person(name="User A", age=20).save()
+        self.Person(name="User C", age=30).save()
+
+        only_age = self.Person.objects.order_by("-age").only("age")
+
+        names = [p.name for p in only_age]
+        ages = [p.age for p in only_age]
+
+        # The .only('age') clause should mean that all names are None
+        self.assertEqual(names, [None, None, None])
+        self.assertEqual(ages, [40, 30, 20])
+
+        qs = self.Person.objects.all().order_by("-age")
+        qs = qs.limit(10)
+        ages = [p.age for p in qs]
+        self.assertEqual(ages, [40, 30, 20])
+
+        qs = self.Person.objects.all().limit(10)
+        qs = qs.order_by("-age")
+
+        ages = [p.age for p in qs]
+        self.assertEqual(ages, [40, 30, 20])
+
+        qs = self.Person.objects.all().skip(0)
+        qs = qs.order_by("-age")
+        ages = [p.age for p in qs]
+        self.assertEqual(ages, [40, 30, 20])
+
+    def test_embedded_only(self):
+        import random
+
+        class Person(EmbeddedDocument):
+            name = StringField()
+            age = DecimalField()
+
+        class Class(EmbeddedDocument):
+            number = DecimalField()
+            literal = StringField()
+
+        class School(EmbeddedDocument):
+            name = StringField()
+            classes = ListField(EmbeddedDocumentField(Class))
+            director = EmbeddedDocumentField(Person)
+
+        class City(Document):
+            schools = ListField(EmbeddedDocumentField(School))
+            name = StringField()
+
+        City.drop_collection()
+
+        literals = 'ABCDEF'
+
+        schools = [
+            {
+                'name': 'School number {}'.format(i), 
+                'director': Person(name='Director {}'.format(i)),
+                'classes': [
+                    {
+                        'number': j,
+                        'literal': random.choice(literals),
+                    } for j in range(random.randint(1, 12))
+                ]
+            } for i in range(10)
+        ]
+
+        City(schools=schools, name='Moscow').save()
+
+        city = City.objects.only('schools.classes.number', 'schools.director.name').first()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/check_fields_retrieved/test_embedded_document_field.py
+++ b/tests/check_fields_retrieved/test_embedded_document_field.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+from mongoengine import (
+    Document,
+    StringField,
+    ValidationError,
+    EmbeddedDocument,
+    EmbeddedDocumentField,
+    InvalidQueryError,
+    LookUpError,
+    IntField,
+    GenericEmbeddedDocumentField,
+    ListField,
+    EmbeddedDocumentListField,
+    ReferenceField,
+)
+
+from tests.utils import MongoDBTestCase
+
+
+class TestEmbeddedDocumentField(MongoDBTestCase):
+
+    def test_query_embedded_document_attribute(self):
+        class AdminSettings(EmbeddedDocument):
+            foo1 = StringField()
+            foo2 = StringField()
+
+        class Person(Document):
+            settings = EmbeddedDocumentField(AdminSettings)
+            name = StringField()
+
+        Person.drop_collection()
+
+        p = Person(settings=AdminSettings(foo1="bar1", foo2="bar2"), name="John").save()
+
+        # Test non exiting attribute
+        with self.assertRaises(InvalidQueryError) as ctx_err:
+            Person.objects(settings__notexist="bar").first()
+        self.assertEqual(unicode(ctx_err.exception), u'Cannot resolve field "notexist"')
+
+        with self.assertRaises(LookUpError):
+            Person.objects.only("settings.notexist")
+
+        # Test existing attribute
+        self.assertEqual(Person.objects(settings__foo1="bar1").first().id, p.id)
+        only_p = Person.objects.only("settings.foo1").first()
+        self.assertEqual(only_p.settings.foo1, p.settings.foo1)
+        self.assertIsNone(only_p.settings.foo2)
+        self.assertIsNone(only_p.name)
+
+        exclude_p = Person.objects.exclude("settings.foo1").first()
+        self.assertIsNone(exclude_p.settings.foo1)
+        self.assertEqual(exclude_p.settings.foo2, p.settings.foo2)
+        self.assertEqual(exclude_p.name, p.name)
+
+    def test_query_embedded_document_attribute_with_inheritance(self):
+        class BaseSettings(EmbeddedDocument):
+            meta = {"allow_inheritance": True}
+            base_foo = StringField()
+
+        class AdminSettings(BaseSettings):
+            sub_foo = StringField()
+
+        class Person(Document):
+            settings = EmbeddedDocumentField(BaseSettings)
+
+        Person.drop_collection()
+
+        p = Person(settings=AdminSettings(base_foo="basefoo", sub_foo="subfoo"))
+        p.save()
+
+        # Test non exiting attribute
+        with self.assertRaises(InvalidQueryError) as ctx_err:
+            self.assertEqual(Person.objects(settings__notexist="bar").first().id, p.id)
+        self.assertEqual(unicode(ctx_err.exception), u'Cannot resolve field "notexist"')
+
+        # Test existing attribute
+        self.assertEqual(Person.objects(settings__base_foo="basefoo").first().id, p.id)
+        self.assertEqual(Person.objects(settings__sub_foo="subfoo").first().id, p.id)
+
+        only_p = Person.objects.only("settings.base_foo", "settings._cls").first()
+        self.assertEqual(only_p.settings.base_foo, "basefoo")
+        self.assertIsNone(only_p.settings.sub_foo)


### PR DESCRIPTION
raise FieldIsNotRetrieved if try to get field not in .only() or in .exclude()